### PR TITLE
feat: starboard module

### DIFF
--- a/src/entity/Starboard.ts
+++ b/src/entity/Starboard.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryColumn, Column } from "typeorm";
+
+@Entity()
+export default class Starboard
+{
+	@PrimaryColumn()
+	messageId: string;
+
+	@Column({
+		nullable: true,
+	})
+	starboardId?: string; // ID of the message in the starboard channel
+
+	@Column()
+	stars: number;
+}

--- a/src/modules/starboard_reaction_add.ts
+++ b/src/modules/starboard_reaction_add.ts
@@ -1,0 +1,77 @@
+import { MessageReaction, MessageEmbed, User, TextChannel } from "discord.js";
+import { getConnection } from "typeorm";
+
+import { Module, IModuleConfig } from "../structures/Module";
+import StarboardEntity from "../entity/Starboard";
+
+const { starboard: { enabled, channel, threshold, emojis } } = require("../../config.json");
+
+class StarboardAdd extends Module
+{
+	public constructor(config: IModuleConfig)
+	{
+		super({
+			client: config.client,
+			enabled,
+			eventName: "messageReactionAdd",
+		});
+	}
+
+	public async handle(reaction: MessageReaction, user: User): Promise<void>
+	{
+		if (user.bot) return;
+
+		console.log("?");
+		const { message, emoji } = reaction;
+		console.log("??");
+		if (!message.guild) return;
+		console.log("???");
+		if (!emojis.includes(emoji.toString())) return;
+
+		const repo = getConnection().getRepository(StarboardEntity);
+		let starboard = await repo.findOne(message.id);
+		starboard = await repo.save({
+			messageId: message.id,
+			starboardId: starboard ? starboard.starboardId : undefined,
+			stars: starboard ? starboard.stars + 1 : 1,
+		});
+		if (starboard.stars < threshold) return;
+
+		const starboardChannel = message.guild.channels.resolve(channel) as TextChannel;
+
+		if (starboard.starboardId)
+		{
+			starboardChannel.messages.resolve(starboard.starboardId)!
+				.edit(`**${starboard.stars}**\\🌟『${message.channel}』`);
+		}
+		else
+		{
+			const starboardEmbed = new MessageEmbed({
+				author: {
+					name: message.author.tag,
+					iconURL: message.author.displayAvatarURL(),
+				},
+				color: 0xffcf05,
+				description: `[Original](${message.url})`,
+				image: {
+					url: message.attachments.first() ? message.attachments.first()!.url : undefined,
+				},
+			}).setTimestamp();
+
+			if (message.content) starboardEmbed.addField("Message", message.content);
+			if (message.embeds.length)
+			{
+				if (message.embeds[0].image) starboardEmbed.setImage(message.embeds[0].image.url);
+			}
+			if (message.attachments.size && !starboardEmbed.image)
+			{
+				starboardEmbed.setImage(message.attachments.first()!.url);
+			}
+
+			const msg = await starboardChannel.send(`**${starboard.stars}**\\🌟『${message.channel}』`, starboardEmbed);
+			repo.update(message.id, { starboardId: msg.id });
+		}
+	}
+}
+
+export { StarboardAdd as Module };

--- a/src/modules/starboard_reaction_add.ts
+++ b/src/modules/starboard_reaction_add.ts
@@ -1,4 +1,4 @@
-import { MessageReaction, MessageEmbed, User, TextChannel } from "discord.js";
+import { Collection, MessageReaction, MessageEmbed, User, TextChannel } from "discord.js";
 import { getConnection } from "typeorm";
 
 import { Module, IModuleConfig } from "../structures/Module";
@@ -21,9 +21,15 @@ class StarboardAdd extends Module
 	{
 		if (user.bot) return;
 
-		const { message, emoji } = reaction;
+		const { message } = reaction;
 		if (!message.guild) return;
-		if (!emojis.includes(emoji.toString())) return;
+		if (message.author.id === user.id) return;
+
+		const reactions: Collection<string, MessageReaction> = message.reactions.cache.filter((reac: MessageReaction) =>
+		{
+			return emojis.includes(reac.emoji.toString()) && reac.users.cache.has(user.id);
+		});
+		if (!reactions.size || reactions.size > 1) return;
 
 		const repo = getConnection().getRepository(StarboardEntity);
 		let starboard = await repo.findOne(message.id);

--- a/src/modules/starboard_reaction_add.ts
+++ b/src/modules/starboard_reaction_add.ts
@@ -21,11 +21,8 @@ class StarboardAdd extends Module
 	{
 		if (user.bot) return;
 
-		console.log("?");
 		const { message, emoji } = reaction;
-		console.log("??");
 		if (!message.guild) return;
-		console.log("???");
 		if (!emojis.includes(emoji.toString())) return;
 
 		const repo = getConnection().getRepository(StarboardEntity);

--- a/src/modules/starboard_reaction_remove.ts
+++ b/src/modules/starboard_reaction_remove.ts
@@ -1,0 +1,52 @@
+import { MessageReaction, User, TextChannel } from "discord.js";
+import { getConnection } from "typeorm";
+
+import { Module, IModuleConfig } from "../structures/Module";
+import StarboardEntity from "../entity/Starboard";
+
+const { starboard: { enabled, channel, threshold, emojis } } = require("../../config.json");
+
+class StarboardRemove extends Module
+{
+	public constructor(config: IModuleConfig)
+	{
+		super({
+			client: config.client,
+			enabled,
+			eventName: "messageReactionRemove",
+		});
+	}
+
+	public async handle(reaction: MessageReaction, user: User): Promise<void>
+	{
+		if (user.bot) return;
+
+		const { message, emoji } = reaction;
+		if (!message.guild) return;
+		if (!emojis.includes(emoji.toString())) return;
+
+		const repo = getConnection().getRepository(StarboardEntity);
+		let starboard = await repo.findOne(message.id);
+		starboard = await repo.save({
+			messageId: message.id,
+			starboardId: starboard ? starboard.starboardId : undefined,
+			stars: starboard ? starboard.stars - 1 : 0,
+		});
+
+		const starboardChannel = message.guild.channels.resolve(channel) as TextChannel;
+
+		if (starboard.stars < threshold)
+		{
+			starboardChannel.messages.resolve(starboard.starboardId!)!.delete();
+			return;
+		}
+
+		if (starboard.starboardId)
+		{
+			starboardChannel.messages.resolve(starboard.starboardId)!
+				.edit(`**${starboard.stars}**\\🌟『${message.channel}』`);
+		}
+	}
+}
+
+export { StarboardRemove as Module };


### PR DESCRIPTION
Creates a module to handle a "starboard."

### What does that means?

This module will look for the emotes set in the configuration file to see if they were added or removed to/from a message and create, edit or delete accordingly in the starboard channel, which is also set in the configuration file.

### Configuration changes

```diff
+	"starboard": {
+		"enabled": false,
+		"channel": "",
+		"threshold": 1,
+		"emojis": []
+	}
```

**Enabled**
> Whether the module is enabled or not, handled by default by the Module structure.

**Channel**
> The channel where the starboard messages will be sent to.

**Threshold**
> Amount of reactions needed to be added to the starboard.

**Emojis**
> The emojis that the application will catch.