### PR TITLE
feat: add self_roles module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,7 @@ module.exports = {
 	env: {
 		node: true,
 	},
-	extends:
-	[
+	extends: [
 		"eslint:recommended",
 		"plugin:@typescript-eslint/eslint-recommended",
 		"plugin:@typescript-eslint/recommended",
@@ -14,64 +13,24 @@ module.exports = {
 		ecmaVersion: 2020,
 		sourceType: "module",
 	},
-	plugins:
-	[
+	plugins: [
 		"@typescript-eslint",
 	],
 	root: true,
-	rules:
-	{
-		/*
-		 * ESLint rules
-		 */
-		"brace-style":
-		[
-			"error",
-			"allman",
-		],
-		"comma-dangle":
-		[
-			"warn",
-			"always-multiline",
-		],
-		curly:
-		[
-			"error",
-			"multi-line",
-		],
-		quotes:
-		[
-			"error",
-			"double",
-			{
-				avoidEscape: true,
-			},
-		],
-		"quote-props":
-		[
-			"error",
-			"as-needed",
-		],
-		semi:
-		[
-			"error",
-			"always",
-		],
+	rules: {
+		"comma-dangle": ["error", "always-multiline"],
+		quotes: ["error", "double", { avoidEscape: true }],
+		"brace-style": ["error", "allman"],
+		curly: ["error", "multi-line"],
+		"quote-props": ["error", "as-needed"],
+		semi: ["error", "always"],
 		"no-trailing-spaces": "error",
-		indent: "off",
-		"no-unexpected-multiline": "off",
-		radix: "off",
-		"require-atomic-updates": "off",
-		/*
-		 * TSLint rules
-		 */
-		"@typescript-eslint/indent":
-		[
-			"error",
-			"tab",
-		],
-		"@typescript-eslint/no-inferrable-types": "off",
+		eqeqeq: ["error", "always"],
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-var-requires": "off",
+
+		// note you must disable the base rule as it can report incorrect errors
+		"no-unused-vars": "off",
+		"@typescript-eslint/no-unused-vars": ["error", { varsIgnorePattern: "^_", argsIgnorePattern: "^_" }],
 	},
 };

--- a/config.json.example
+++ b/config.json.example
@@ -20,5 +20,9 @@
 		"channel": "",
 		"upvoteEmoji": "",
 		"downvoteEmoji": ""
+	},
+	"self_role": {
+		"enabled": false,
+		"channel": ""
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,24 +8,23 @@
 	"license": "MPL2",
 	"private": true,
 	"dependencies": {
-		"discord.js": "^12.5.1",
+		"discord.js": "^13.0.0-dev.cbd7f2b9aa44a9240947ed716d0e72257ac499f7",
 		"node-cron": "^2.0.3",
 		"pg": "^8.5.0",
 		"reflect-metadata": "^0.1.13",
 		"typeorm": "^0.2.29",
-		"typescript": "^4.0.5"
+		"typescript": "4.3.2"
 	},
 	"devDependencies": {
 		"@types/node": "^14.14.7",
 		"@types/node-cron": "^2.0.3",
-		"@types/ws": "^7.4.0",
 		"@typescript-eslint/eslint-plugin": "^4.7.0",
 		"@typescript-eslint/parser": "^4.7.0",
 		"eslint": "^7.13.0"
 	},
 	"scripts": {
 		"build": "tsc -p ./",
-		"start": "cd bin && node index.js",
+		"start": "cd bin && node --enable-source-maps index.js",
 		"lint": "eslint --ext .js,.ts src"
 	}
 }

--- a/src/entity/SelfRole.ts
+++ b/src/entity/SelfRole.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+
+@Entity()
+export default class SelfRole
+{
+	@PrimaryColumn()
+	id: string;
+
+	@Column({ type: "int", nullable: false })
+	style: number;
+
+	// The format is `a|${name}|${id}` for custom emojis or `${emoji}` for default emojis.
+	// THIS IS NOT VALIDATED (because you can only do that by hitting up Discord with some request)
+	@Column({ type: "text", nullable: true })
+	emoji: string | null;
+}

--- a/src/entity/Starboard.ts
+++ b/src/entity/Starboard.ts
@@ -1,15 +1,16 @@
+import { Snowflake } from "discord.js";
 import { Entity, PrimaryColumn, Column } from "typeorm";
 
 @Entity()
 export default class Starboard
 {
 	@PrimaryColumn()
-	messageId: string;
+	messageId: Snowflake;
 
 	@Column({
 		nullable: true,
 	})
-	starboardId?: string; // ID of the message in the starboard channel
+	starboardId?: Snowflake; // ID of the message in the starboard channel
 
 	@Column()
 	stars: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,13 @@ new Database().start();
 
 const client: Client = new Client({
 	allowedMentions: { parse: ["users"] },
-	ws: {
-		intents: [
-			"GUILDS",
-			"DIRECT_MESSAGES",
-			"GUILD_MESSAGES",
-			"GUILD_MESSAGE_REACTIONS",
-			"GUILD_MEMBERS",
-		],
-	},
+	intents: [
+		"GUILDS",
+		"DIRECT_MESSAGES",
+		"GUILD_MESSAGES",
+		"GUILD_MESSAGE_REACTIONS",
+		"GUILD_MEMBERS",
+	],
 	partials: ["MESSAGE", "REACTION", "USER"],
 });
 

--- a/src/modules/self_role.ts
+++ b/src/modules/self_role.ts
@@ -1,0 +1,398 @@
+import
+{
+	ApplicationCommandData,
+	MessageComponentInteraction,
+	CommandInteraction,
+	CommandInteractionOption,
+	Constants,
+	DiscordAPIError,
+	GuildMember,
+	Interaction,
+	MessageActionRowOptions,
+	MessageButtonOptions,
+	MessageOptions,
+	Role,
+	TextChannel,
+	Snowflake,
+} from "discord.js";
+import { getConnection } from "typeorm";
+
+import SelfRole from "../entity/SelfRole";
+import { IModuleConfig, Module } from "../structures/Module";
+import { chunkArray } from "../util";
+
+const { ApplicationCommandOptionTypes, MessageButtonStyles, MessageComponentTypes } = Constants;
+
+const { self_role: { enabled, channel: channelID } } = require("../../config.json");
+
+const CUSTOM_ID_PREFIX = "self-role-";
+
+enum SubCommand
+// eslint-disable-next-line @typescript-eslint/indent
+{
+	add,
+	remove,
+	show,
+	deploy,
+	cleanup
+}
+
+export const SelfRoleCommand: ApplicationCommandData = {
+	name: "selfrole",
+	description: "Manage available self roles.",
+	defaultPermission: false,
+	options: [
+		{
+			name: SubCommand[SubCommand.add],
+			type: ApplicationCommandOptionTypes.SUB_COMMAND,
+			description: "Add a role to the list of available self roles.",
+			options: [{
+				name: "role",
+				type: ApplicationCommandOptionTypes.ROLE,
+				description: "The role to add to the list of self roles.",
+				required: true,
+			},
+			{
+				name: "style",
+				type: ApplicationCommandOptionTypes.INTEGER,
+				description: "The button style to use",
+				choices: [
+					{
+						name: "Primary (Blurple)",
+						value: MessageButtonStyles.PRIMARY,
+					},
+					{
+						name: "Secondary (Grey)",
+						value: MessageButtonStyles.SECONDARY,
+					},
+					{
+						name: "Success (Green)",
+						value: MessageButtonStyles.SUCCESS,
+					},
+					{
+						name: "Danger (Red)",
+						value: MessageButtonStyles.DANGER,
+					},
+				],
+			},
+			{
+				name: "emoji",
+				type: ApplicationCommandOptionTypes.STRING,
+				description: "The emoji to use. (Make sure its actually valid)",
+			}],
+		},
+		{
+			name: SubCommand[SubCommand.remove],
+			type: ApplicationCommandOptionTypes.SUB_COMMAND,
+			description: "Remove a role from the list of available self roles.",
+			options: [{
+				name: "role",
+				type: ApplicationCommandOptionTypes.ROLE,
+				description: "The role to remove from the list of self roles.",
+				required: true,
+			}],
+		},
+		{
+			name: SubCommand[SubCommand.show],
+			type: ApplicationCommandOptionTypes.SUB_COMMAND,
+			description: "Show all available self roles.",
+		},
+		{
+			name: SubCommand[SubCommand.deploy],
+			type: ApplicationCommandOptionTypes.SUB_COMMAND,
+			description: "Deploys the self role message.",
+		},
+		{
+			name: SubCommand[SubCommand.cleanup],
+			type: ApplicationCommandOptionTypes.SUB_COMMAND,
+			description: "Removes deleted roles from the list of self assignable roles.",
+		},
+	],
+};
+
+class SelfRoleModule extends Module
+{
+	public constructor(config: IModuleConfig)
+	{
+		super({
+			client: config.client,
+			enabled,
+			eventName: "interaction",
+		});
+	}
+
+	protected override async handle(interaction: Interaction): Promise<void>
+	{
+		if (!interaction.guildID) return;
+		if (interaction instanceof MessageComponentInteraction)
+		{
+			if (!interaction.customID.startsWith(CUSTOM_ID_PREFIX))
+			{
+				return;
+			}
+
+			return this.button(interaction);
+		}
+
+		if (interaction instanceof CommandInteraction)
+		{
+			if (interaction.commandName !== SelfRoleCommand.name)
+			{
+				return;
+			}
+
+			if (!interaction.guild)
+			{
+				await interaction.reply(
+					"This guild is not available, the bot might not be fully started yet."
+					+ " If this error persists, contact an administrator.",
+					{ ephemeral: true },
+				);
+
+				return;
+			}
+
+			const subCommand = interaction.options.values().next().value as CommandInteractionOption;
+			if (!subCommand) throw new Error("No sub command present.");
+
+			const subCommandName = subCommand.name;
+
+			if (isSubCommand(subCommandName))
+			{
+				this[subCommandName](interaction, subCommand.options!);
+			}
+		}
+	}
+
+	private async button(interaction: MessageComponentInteraction)
+	{
+		if (interaction.channelID !== channelID) return;
+		if (!interaction.guild)
+		{
+			await interaction.reply(
+				"This guild is not available, the bot might not be fully started yet.\n"
+				+ "If this error persists, contact an administrator.",
+				{ ephemeral: true },
+			);
+
+			return;
+		}
+
+		const roleID = interaction.customID.slice(CUSTOM_ID_PREFIX.length);
+
+		const role = interaction.guild.roles.resolve(roleID);
+		if (!role)
+		{
+			await interaction.reply(
+				"Couldn't find the role for this button.\n"
+				+ "If this error, persists contact an administrator.",
+				{ ephemeral: true },
+			);
+			return;
+		}
+
+		const selfRole = await getConnection().getRepository(SelfRole).findOne(roleID);
+		if (!selfRole)
+		{
+			await interaction.reply(
+				`${role} is not designated to be self assignable.\n`
+				+ "If this error, persists contact an administrator.",
+				{ ephemeral: true },
+			);
+
+			return;
+		}
+
+		const member = interaction.member as GuildMember;
+		if (member.roles.cache.has(role.id))
+		{
+			await member.roles.remove(role);
+			await interaction.reply(`Successfully removed ${role} from you.`, { ephemeral: true });
+		}
+		else
+		{
+			await member.roles.add(role);
+			await interaction.reply(`Successfully added ${role} to you.`, { ephemeral: true });
+		}
+	}
+
+	private async add(interaction: CommandInteraction, options: Map<string, CommandInteractionOption>)
+	{
+		const repo = getConnection().getRepository(SelfRole);
+
+		const roleID = options.get("role")!.role!.id;
+		const style = options.get("style")?.value as number ?? MessageButtonStyles.PRIMARY;
+		let emoji = options.get("emoji")?.value as string ?? null;
+
+		if (roleID === interaction.guildID)
+		{
+			await interaction.reply(
+				"The everyone role may not be self-assignable; It's the everyone role after all.",
+				{ ephemeral: true },
+			);
+			return;
+		}
+
+		// Try to detect custom emojis
+		const match = emoji?.match(/^<(a)?:(\w{2,32}):(\d{16,21})>$/);
+		if (match)
+		{
+			emoji = match.slice(1).join("|");
+		}
+
+		const selfrole = await repo.findOne(roleID);
+
+		await repo.save({ id: roleID, style, emoji });
+		const response = selfrole
+			? `The <@&${roleID}> role is now self assignable.\n`
+			+ "Make sure to `/selfrole deploy` this change."
+			: `Updated style and emoji for the <@&${roleID}> role.\n`
+			+ "Make sure to `/selfrole deploy` this change.";
+
+		await interaction.reply(response);
+	}
+
+	private async remove(interaction: CommandInteraction, options: Map<string, CommandInteractionOption>)
+	{
+		const repo = getConnection().getRepository(SelfRole);
+
+		const roleID = options.get("role")!.role!.id;
+		const selfrole = await repo.findOne(roleID);
+
+		if (selfrole)
+		{
+			await repo.remove(selfrole);
+			await interaction.reply(
+				`The <@&${roleID}> role is no longer self assignable.\n`
+				+ "Make sure to `/selfrole deploy` this change.",
+			);
+		}
+		else
+		{
+			await interaction.reply(`The <@&${roleID}> role is not self assignable.`, { ephemeral: true });
+		}
+	}
+
+	private async show(interaction: CommandInteraction)
+	{
+		const repo = getConnection().getRepository(SelfRole);
+
+		const roles = await repo.find();
+
+		if (!roles.length)
+		{
+			await interaction.reply("There are no self assignable roles.");
+		}
+		else
+		{
+			const roleString = roles.map(r =>
+				`<@&${r.id}> (emoji: ${r.emoji ?? "none"}, style: ${MessageButtonStyles[r.style] ?? r.style})`,
+			).join(", ");
+
+			await interaction.reply(
+				`Self assignable roles are: ${roleString}`,
+			);
+		}
+	}
+
+	private async deploy(interaction: CommandInteraction)
+	{
+		const repo = getConnection().getRepository(SelfRole);
+
+		const channel = this.client.channels.resolve(channelID);
+		if (!channel)
+		{
+			await interaction.reply(
+				`The designated channel for self roles (<#${channelID}> / ${channelID}) could not be found.`,
+			);
+
+			return;
+		}
+
+		if (!(channel instanceof TextChannel))
+		{
+			await interaction.reply(
+				`The designated channel for self roles (<#${channelID}> / ${channelID}) is not a text channel.`,
+			);
+
+			return;
+		}
+
+		const roles = (await repo.find())
+			.map(r => [r, interaction.guild?.roles.resolve(r.id)])
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			.filter(([_, r]) => r) as [SelfRole, Role][];
+
+		const options: MessageOptions = {
+			content: "Click the buttons below to toggle a role on you.",
+			components: chunkArray(roles, 5)
+				.map<MessageActionRowOptions>(row =>
+				({
+					type: MessageComponentTypes.ACTION_ROW,
+					components: row.map<MessageButtonOptions>(([info, role]) => ({
+						type: MessageComponentTypes.BUTTON,
+						label: role.name,
+						style: info.style,
+						customID: `${CUSTOM_ID_PREFIX}${role.id}`,
+						emoji: buildEmoji(info.emoji),
+					})),
+				})),
+		};
+
+		try
+		{
+			await channel.send(options);
+			await interaction.reply(
+				`Successfully sent a message for self roles into ${channel}.`
+				+ "\nYou may want to delete the old message if you did not already.",
+			);
+		}
+		catch (error: unknown)
+		{
+			await interaction.reply(
+				`Failed to send the message: \`${(error as DiscordAPIError).message}\``,
+			);
+
+			throw error;
+		}
+	}
+
+	private async cleanup(interaction: CommandInteraction)
+	{
+		const repo = getConnection().getRepository(SelfRole);
+
+		const selfRoles = await repo.find();
+		const missing = selfRoles.filter(r => !interaction.guild!.roles.resolve(r.id));
+		if (!missing.length)
+		{
+			await interaction.reply("There are no roles to prune.", { ephemeral: true });
+		}
+		else
+		{
+			await repo.remove(missing);
+			await interaction.reply(
+				`Removed ${missing.length} no longer existing self assignable roles from the list.`,
+			);
+		}
+	}
+}
+
+function isSubCommand(candidate: string): candidate is keyof typeof SubCommand
+{
+	return Reflect.has(SubCommand, candidate);
+}
+
+function buildEmoji(emoji: string | null)
+{
+	if (!emoji) return undefined;
+	if (!emoji.includes("|")) return { name: emoji, id: null };
+	const [animated, name, id] = emoji.split("|");
+
+	return {
+		animated: animated === "a",
+		name,
+		id: id as Snowflake,
+	};
+}
+
+export { SelfRoleModule as Module };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+/**
+ * Split an array into smaller cunks.
+ * The original array will _not_ be modified.
+ */
+export const chunkArray: <T>(input: readonly T[], chunkSize: number) => T[][]
+	= <T>(input: readonly T[], chunkSize: number): T[][] =>
+	{
+		const chunks: T[][] = [];
+		const length: number = Math.ceil(input.length / chunkSize);
+
+		for (let i = 0; i < length; undefined)
+		{
+			chunks.push(input.slice(i * chunkSize, ++i * chunkSize));
+		}
+
+		return chunks;
+	};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"compilerOptions": {
-		"allowSyntheticDefaultImports": true,
 		"alwaysStrict": true,
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,
-		"isolatedModules": true,
 		"lib": ["ESNext"],
 		"module": "CommonJS",
 		"moduleResolution": "Node",
@@ -17,7 +15,8 @@
 		"rootDir": "src",
 		"strict": true,
 		"strictPropertyInitialization": false,
-		"target": "ESNext"
+		"target": "ES2020",
+		"noImplicitOverride": true
 	},
 	"include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@sapphire/async-queue@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.2.tgz#df44c9ece32d0a04b9b52f87d65ddf0135254176"
+  integrity sha512-NkR7AzC9uyb++tMIZgG4X0ci8JM1rnvNmKbLwY42RgotRV8JGUntZ7ZpR7MN7p5zPlVdKo/YmOqcCCsBJ6LNuw==
+
 "@sqltools/formatter@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.2.tgz#9390a8127c0dcba61ebd7fdcc748655e191bdd68"
@@ -101,10 +106,10 @@
   resolved "https://registry.yarnpkg.com/@types/tz-offset/-/tz-offset-0.0.0.tgz#d58f1cebd794148d245420f8f0660305d320e565"
   integrity sha512-XLD/llTSB6EBe3thkN+/I0L+yCTB6sjrcVovQdx2Cnl6N6bTzHmwe/J8mWnsXFgxLrj/emzdv8IR4evKYG2qxQ==
 
-"@types/ws@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.0.tgz#499690ea08736e05a8186113dac37769ab251a0e"
-  integrity sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==
+"@types/ws@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.4.tgz#93e1e00824c1de2608c30e6de4303ab3b4c0c9bc"
+  integrity sha512-d/7W23JAXPodQNbOZNXvl2K+bqAQrCMwlh/nuQsPSQk6Fq0opHoPrUw43aHsvSbIiQPr8Of2hkFbnz1XBFVyZQ==
   dependencies:
     "@types/node" "*"
 
@@ -451,19 +456,26 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord.js@^12.5.1:
-  version "12.5.1"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-12.5.1.tgz#992b45753e3815526a279914ccc281d3496f5990"
-  integrity sha512-VwZkVaUAIOB9mKdca0I5MefPMTQJTNg0qdgi1huF3iwsFwJ0L5s/Y69AQe+iPmjuV6j9rtKoG0Ta0n9vgEIL6w==
+discord-api-types@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.18.1.tgz#5d08ed1263236be9c21a22065d0e6b51f790f492"
+  integrity sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==
+
+discord.js@^13.0.0-dev.cbd7f2b9aa44a9240947ed716d0e72257ac499f7:
+  version "13.0.0-dev.cbd7f2b9aa44a9240947ed716d0e72257ac499f7"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.0.0-dev.cbd7f2b9aa44a9240947ed716d0e72257ac499f7.tgz#db6253c7fb4c504467ac2ca849fa88a03565072d"
+  integrity sha512-QgKFli1hpw0DOQ7CHAfl32TYglWRgamQrTqtZkvv3e/rXzumKUfsX4KgPPON71U+T/JAjewi0UOM4UQnwP9ttQ==
   dependencies:
     "@discordjs/collection" "^0.1.6"
     "@discordjs/form-data" "^3.0.1"
+    "@sapphire/async-queue" "^1.1.2"
+    "@types/ws" "^7.4.4"
     abort-controller "^3.0.0"
+    discord-api-types "^0.18.1"
     node-fetch "^2.6.1"
-    prism-media "^1.2.2"
-    setimmediate "^1.0.5"
+    prism-media "^1.2.9"
     tweetnacl "^1.0.3"
-    ws "^7.3.1"
+    ws "^7.4.6"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -895,17 +907,17 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
 mime-types@^2.1.12:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.48.0"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -1136,10 +1148,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prism-media@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.3.tgz#37bbb11726674a73fe56a2df4de76aa91d2141b7"
-  integrity sha512-fSrR66n0l6roW9Rx4rSLMyTPTjRTiXy5RVqDOurACQ6si1rKHHKDU5gwBJoCsIV0R3o9gi+K50akl/qyw1C74A==
+prism-media@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.9.tgz#8d4f97b36efdfc82483eb8d3db64020767866f36"
+  integrity sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q==
 
 progress@^2.0.0:
   version "2.0.3"
@@ -1223,11 +1235,6 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.11:
   version "2.4.11"
@@ -1416,10 +1423,10 @@ typeorm@^0.2.29:
     yargonaut "^1.1.2"
     yargs "^16.0.3"
 
-typescript@^4.0.5:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 tz-offset@0.0.1:
   version "0.0.1"
@@ -1483,7 +1490,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^7.3.1:
+ws@^7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==


### PR DESCRIPTION
This PR adds a new module: `SelfRole`

This module will allow members to self-assign roles through the click of a button (not reaction!).
These buttons act as a toggle, so they can remove the roles from themselves by clicking the button again.

This PR is also updated `discord.js` from `12.5.3` to the `dev` branch.
The breaking changes do not seem to have affected us here.

This PR also updates `typescript` to `4.3` to use the override keyword.
Although I couldn't get `noImplicitOverride` to work yet.